### PR TITLE
Multiple updates to support local development and civibuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,4 @@
 !/web/static/css
 
 #not sure how else to ensure that the following two files aren't deployed on prod
-/web/app_dev.php
 /web/config.php

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -48,14 +48,22 @@ class AppKernel extends Kernel
         $loader->load($this->getRootDir().'/config/config_'.$this->getEnvironment().'.yml');
     }
 
-    protected function initializeContainer()
+    protected function buildContainer()
     {
-        parent::initializeContainer();
-        if ($this->getContainer()->hasParameter('mkdocs_path')) {
-            $_ENV['PATH'] = $this->getContainer()->getParameter('mkdocs_path')
+        $container = parent::buildContainer();
+        if ($container->hasParameter('mkdocs_path')) {
+            $_ENV['PATH'] = $container->getParameter('mkdocs_path')
               . PATH_SEPARATOR . getenv('PATH');
             putenv("PATH=" . $_ENV['PATH']);
         }
+        if (!$container->hasParameter('publisher_repos_dir')) {
+            // This isn't really a good place to put it because it gets deleted
+            // whenever you clear the cache.
+            $container->setParameter('publisher_repos_dir',
+              $container->getParameter('kernel.cache_dir') . '/repos'
+            );
+        }
+        return $container;
     }
 
 

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -47,4 +47,16 @@ class AppKernel extends Kernel
     {
         $loader->load($this->getRootDir().'/config/config_'.$this->getEnvironment().'.yml');
     }
+
+    protected function initializeContainer()
+    {
+        parent::initializeContainer();
+        if ($this->getContainer()->hasParameter('mkdocs_path')) {
+            $_ENV['PATH'] = $this->getContainer()->getParameter('mkdocs_path')
+              . PATH_SEPARATOR . getenv('PATH');
+            putenv("PATH=" . $_ENV['PATH']);
+        }
+    }
+
+
 }

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -17,3 +17,6 @@ parameters:
 
     # A secret key that's used to generate certain security-related tokens
     secret:            ThisTokenIsNotSoSecretChangeIt
+
+    # Load mkdocs from a non-standard directory, e.g.
+    # mkdocs_path:       /Applications/MAMP/Library/bin

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -20,3 +20,5 @@ parameters:
 
     # Load mkdocs from a non-standard directory, e.g.
     # mkdocs_path:       /Applications/MAMP/Library/bin
+
+    # publisher_repos_dir: '%kernel.root_dir%/repos'

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -12,7 +12,7 @@ services:
         arguments: ['@publisher']
     publisher:
         class: AppBundle\Utils\Publisher
-        arguments: ['@request_stack', '@publish.logger', '@filesystem', %kernel.root_dir%/config/books, %kernel.cache_dir%/repos, %kernel.root_dir%/../web/static]
+        arguments: ['@request_stack', '@publish.logger', '@filesystem', %kernel.root_dir%/config/books, %publisher_repos_dir%, %kernel.root_dir%/../web/static]
     publish.logger:
         class: Monolog\Logger
         arguments: ['publish', ['@streamhandler']]

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -4,6 +4,9 @@ parameters:
 #    parameter_name: value
 
 services:
+    book.loader:
+        class: AppBundle\BookLoader
+        arguments: ['%kernel.root_dir%/config/books']
     github.hook.processor:
         class: AppBundle\Utils\GitHubHookProcessor
         arguments: ['@publisher']

--- a/src/AppBundle/BookLoader.php
+++ b/src/AppBundle/BookLoader.php
@@ -59,13 +59,14 @@ class BookLoader
         foreach ($this->find() as $bookName => $book) {
             foreach ($book['langs'] as $lang => $langSpec) {
                 foreach ($this->getBranches($book, $lang) as $branch) {
+                    $key = "$bookName/$lang/$branch";
                     $row =  array(
                       'book' => $bookName,
                       'lang' => $lang,
                       'repo' => $langSpec['repo'],
                       'branch' => $branch,
                     );
-                    $rows[] = $row;
+                    $rows[$key] = $row;
                 }
             }
         }

--- a/src/AppBundle/BookLoader.php
+++ b/src/AppBundle/BookLoader.php
@@ -1,0 +1,102 @@
+<?php
+namespace AppBundle;
+
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Yaml\Parser;
+
+class BookLoader
+{
+
+    /**
+     * @var string
+     */
+    private $configDir;
+
+    /**
+     * @var array
+     */
+    private $cache;
+
+    /**
+     * Books constructor.
+     * @param string $configDir
+     */
+    public function __construct($configDir)
+    {
+        $this->configDir = $configDir;
+    }
+
+    /**
+     * @return array
+     */
+    public function find()
+    {
+        if ($this->cache === null) {
+            $finder = new Finder();
+            $yaml = new Parser();
+            $books = array();
+            foreach ($finder->in($this->configDir)
+                       ->name("*.yml") as $file) {
+                $books[basename($file, '.yml')] = $yaml->parse(file_get_contents("$file"));
+            }
+            $this->cache = $books;
+        }
+        return $this->cache;
+    }
+
+    /**
+     * Get the list of books as a flat list of (book,lang,repo,branch) pairs.
+     *
+     * @return array
+     *   Each item in the array contains keys:
+     *     - book: string (ex: 'dev')
+     *     - lang: string (ex: 'en')
+     *     - repo: string (ex: 'https://example.com/dev.git')
+     *     - branch: string (ex: 'master')
+     */
+    public function findAsList() {
+        $rows = array();
+        foreach ($this->find() as $bookName => $book) {
+            foreach ($book['langs'] as $lang => $langSpec) {
+                foreach ($this->getBranches($book, $lang) as $branch) {
+                    $row =  array(
+                      'book' => $bookName,
+                      'lang' => $lang,
+                      'repo' => $langSpec['repo'],
+                      'branch' => $branch,
+                    );
+                    $rows[] = $row;
+                }
+            }
+        }
+        return $rows;
+    }
+
+    /**
+     * Get a list of all branches declared for this book.
+     *
+     * @param array $book
+     * @param string $lang
+     * @return array
+     *   List of branch names which apply to this book.
+     */
+    public function getBranches($book, $lang) {
+        $langSpec = $book['langs'][$lang];
+        $branches = array();
+        foreach (array('latest', 'stable', 'history') as $key) {
+            if (!isset($langSpec[$key])) {
+                continue;
+            }
+            elseif (is_array($langSpec[$key])) {
+                $branches = array_merge($branches,$langSpec[$key]);
+            }
+            else {
+                $branches[] = $langSpec[$key];
+            }
+        }
+        $branches = array_unique($branches);
+        sort($branches);
+        return $branches;
+    }
+
+}

--- a/src/AppBundle/Command/DocsListCommand.php
+++ b/src/AppBundle/Command/DocsListCommand.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace AppBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class DocsListCommand extends ContainerAwareCommand
+{
+    protected function configure()
+    {
+        $this
+          ->setName('docs:list')
+          ->setDescription('List available books');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        /** @var \AppBundle\BookLoader $books */
+        $books = $this->getContainer()->get('book.loader');
+        $table = new Table($output);
+        $table->setHeaders(array('book', 'lang', 'repo', 'branch'));
+        $table->addRows($books->findAsList());
+        $table->render();
+    }
+
+}

--- a/src/AppBundle/Command/DocsPublishCommand.php
+++ b/src/AppBundle/Command/DocsPublishCommand.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace AppBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class DocsPublishCommand extends ContainerAwareCommand
+{
+    protected function configure()
+    {
+        $this
+          ->setName('docs:publish')
+          ->setDescription('...')
+          ->addArgument('paths', InputArgument::IS_ARRAY,
+            'One or more book expressions ("book/lang/branch"). (Default: all)');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        /** @var \AppBundle\BookLoader $books */
+        $books = $this->getContainer()->get('book.loader');
+
+        /** @var \AppBundle\Utils\Publisher $publisher */
+        $publisher = $this->getContainer()->get('publisher');
+
+        $rows = $books->findAsList();
+
+        if (empty($rows)) {
+            $output->writeln("<error>No books found</error>");
+        }
+
+        $rowKeys = $input->getArgument('paths') ? $input->getArgument('paths') : array_keys($rows);
+
+        foreach ($rowKeys as $rowKey) {
+            $row = $rows[$rowKey];
+            $output->writeln("");
+            $output->writeln(sprintf("Publish [%s/%s/%s] (from %s)",
+              $row['book'], $row['lang'], $row['branch'], $row['repo']));
+
+            $publisher->publish($row['book'], $row['lang'], $row['branch']);
+
+            foreach ($publisher->getMessages() as $message) {
+                $output->writeln($message['label'] . ': ' . $message['content']);
+            }
+            $publisher->clearMessages();
+
+        }
+    }
+
+}

--- a/src/AppBundle/Command/DocsServeCommand.php
+++ b/src/AppBundle/Command/DocsServeCommand.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace AppBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Class DocsServeCommand
+ * @package AppBundle\Command
+ *
+ * This is a dumb wrapper around `mkdocs serve`. It basically just cd's into the
+ * appropriate folder and then passes-through the args.
+ */
+class DocsServeCommand extends ContainerAwareCommand
+{
+    protected function configure()
+    {
+        $this
+          ->setName('docs:serve')
+          ->setDescription('Run the builtin docs development server')
+          ->addOption('dev-addr', 'a', InputOption::VALUE_OPTIONAL,
+            'IP address and port to serve documentation')
+          ->addOption('strict', 's', InputOption::VALUE_NONE,
+            'Enable strict mode. This will cause MkDocs to abort the build on any warnings.')
+          ->addOption('theme', 't', InputOption::VALUE_OPTIONAL,
+            'The theme to use when building your documentation [cosmo|cyborg|readthedocs|yeti|journal|bootstrap|readable|united|simplex|flatly|spacelab|amelia|cerulean|slate|mkdocs')
+          ->addOption('livereload', null, InputOption::VALUE_NONE,
+            'Enable the live reloading in the development server.')
+          ->addOption('no-livereload', null, InputOption::VALUE_NONE,
+            'Enable the live reloading in the development server.')
+          ->addOption('quiet', 'q', InputOption::VALUE_NONE,
+            'Silence warnings')//          ->addOption('verbose', 'v', InputOption::VALUE_NONE, 'Enable verbose output')
+          ->addArgument('[book/lang/[branch]]', InputArgument::REQUIRED,
+            'A book expression (e.g. "dev/en/master" or "user/fr/4.6"). The [book] and [lang] are mandatory. If [branch] is specified, it will be checked out.')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        if (preg_match(';^(\w+)/(\w+)?$;', $input->getArgument('[book/lang/[branch]]'), $matches)) {
+            $book = $matches[1];
+            $lang = $matches[2];
+            $branch = NULL;
+        } elseif (preg_match(';^(\w+)/(\w+)/(\w+)$;', $input->getArgument('[book/lang/[branch]]'), $matches)) {
+            $book = $matches[1];
+            $lang = $matches[2];
+            $branch = $matches[3];
+        } else {
+            $output->writeln("<error>Malformed [book/lang/branch]</error>");
+            return 1;
+        }
+
+        $repoDir = $this->getContainer()->getParameter('publisher_repos_dir') . "/$book/$lang";
+
+        if (file_exists($repoDir)) {
+            $output->writeln("<info>Found git repo for $book/$lang in \"$repoDir\"</info>");
+        } else {
+            $output->writeln("<error>Failed to find git repo for $book/$lang in \"$repoDir\".</error>");
+            $output->writeln("<error>Perhaps you should run \"docs:publish\" first?</error>");
+            return 1;
+        }
+
+        $command = 'mkdocs serve';
+        foreach (array('dev-addr', 'theme') as $option) {
+            if ($input->getOption($option)) {
+                $command .= " --{$option} " . escapeshellarg($input->getOption($option));
+            }
+        }
+        foreach (array('strict', 'livereload', 'no-livereload', 'quiet') as $option) {
+            if ($input->getOption($option) ) {
+                $command .= " --{$option}";
+            }
+        }
+
+        if ($branch) {
+            $output->writeln("<info>Check out branch \"$branch\"</info>");
+            self::passthruOK($repoDir, "git checkout $branch");
+        }
+        $output->writeln("<info>Launch \"$command\"</info>");
+        self::passthruOK($repoDir, $command);
+    }
+
+    protected function passthruOK($newcwd, $command) {
+        $oldcwd = getcwd();
+        chdir($newcwd);
+        passthru($command, $return);
+        chdir($oldcwd);
+        if ($return) {
+            throw new \RuntimeException("Received error from command ($command)");
+        }
+    }
+
+}

--- a/src/AppBundle/Controller/PublishController.php
+++ b/src/AppBundle/Controller/PublishController.php
@@ -55,6 +55,8 @@ class PublishController extends Controller
         }
         $event = $request->headers->get('X-GitHub-Event');
         $payload = json_decode($body);
+
+        // FIXME: $books = $container->get('book.loader')->find();
         $finder = new Finder();
         $yaml = new Parser();
         foreach ($finder->in($this->get('kernel')->getRootDir().'/config/books')->name("*.yml") as $file) {

--- a/src/AppBundle/Utils/Publisher.php
+++ b/src/AppBundle/Utils/Publisher.php
@@ -11,12 +11,14 @@ use Symfony\Component\HttpFoundation\RequestStack;
 class Publisher{
     
     public $bookConfigFile;
+
+    public $messages;
     
     public function __construct(RequestStack $requestStack, $logger, $fs, $configDir, $reposRoot, $publishRoot){
         $this->configDir = $configDir;
         $this->reposRoot = $reposRoot;
         $this->publishRoot = $publishRoot;
-        $this->baseUrl = $requestStack->getCurrentRequest()->getUriForPath('');
+        $this->baseUrl = $requestStack->getCurrentRequest() ? $requestStack->getCurrentRequest()->getUriForPath('') : '/';
         //$this->baseUrl = $requestStack->getCurrentRequest()->$getBaseUrl();
         $this->logger = $logger;
         $this->fs = $fs;
@@ -112,7 +114,7 @@ class Publisher{
         $publishDir = $this->publishRoot."/{$book}/{$lang}/{$branch}";
         $buildCommand = "mkdocs build -c -f {$buildConfigFile} -d {$publishDir}";
         $this->addMessage('NOTICE', "Running '{$buildCommand}'");
-        
+
         $mkdocs = new Process($buildCommand, $bookRepo);
         $mkdocsErrors = false;
         $mkdocs->run();
@@ -164,9 +166,30 @@ class Publisher{
         $this->messages[] = array('label' => $label, 'content' => $content);
         $this->logger->addRecord($this->logger->toMonologLevel($label), $content);
     }
+
     public function getMessages()
     {
         return $this->messages;
     }
-    
+
+    public function clearMessages() {
+        $this->messages = array();
+    }
+
+    /**
+     * @return string
+     */
+    public function getBaseUrl()
+    {
+        return $this->baseUrl;
+    }
+
+    /**
+     * @param string $baseUrl
+     */
+    public function setBaseUrl($baseUrl)
+    {
+        $this->baseUrl = $baseUrl;
+    }
+
 }

--- a/web/.htaccess
+++ b/web/.htaccess
@@ -3,7 +3,7 @@
 # mod_rewrite). Additionally, this reduces the matching process for the
 # start page (path "/") because otherwise Apache will apply the rewriting rules
 # to each configured DirectoryIndex file (e.g. index.php, index.html, index.pl).
-DirectoryIndex app.php
+DirectoryIndex app.php index.html
 
 # By default, Apache does not evaluate symbolic links if you did not enable this
 # feature in your server configuration. Uncomment the following line if you
@@ -51,6 +51,9 @@ DirectoryIndex app.php
     # If the requested filename exists, simply serve it.
     # We only want to let Apache serve files and not directories.
     RewriteCond %{REQUEST_FILENAME} -f
+    RewriteRule ^ - [L]
+
+    RewriteCond %{REQUEST_FILENAME} -d
     RewriteRule ^ - [L]
 
     # Rewrite all other queries to the front controller.

--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -1,0 +1,32 @@
+<?php
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Debug\Debug;
+
+// If you don't want to setup permissions the proper way, just uncomment the following PHP line
+// read http://symfony.com/doc/current/book/installation.html#checking-symfony-application-configuration-and-setup
+// for more information
+//umask(0000);
+
+// This check prevents access to debug front controllers that are deployed by accident to production servers.
+// Feel free to remove this, extend it, or make something more sophisticated.
+if (isset($_SERVER['HTTP_CLIENT_IP'])
+    || isset($_SERVER['HTTP_X_FORWARDED_FOR'])
+    || !(in_array(@$_SERVER['REMOTE_ADDR'], ['127.0.0.1', 'fe80::1', '::1']) || php_sapi_name() === 'cli-server')
+) {
+    header('HTTP/1.0 403 Forbidden');
+    exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');
+}
+
+/**
+ * @var Composer\Autoload\ClassLoader $loader
+ */
+$loader = require __DIR__.'/../app/autoload.php';
+Debug::enable();
+
+$kernel = new AppKernel('dev', true);
+$kernel->loadClassCache();
+$request = Request::createFromGlobals();
+$response = $kernel->handle($request);
+$response->send();
+$kernel->terminate($request, $response);


### PR DESCRIPTION
Buildkit includes a configuration for `docs`, but it doesn't work well
during setup because nothing will be initialized until you enter in some
secret URLs.

This adds a single command, `bin/console docs:publish`, which publishes
everything listed in the *.yml files.

Additionally, this PR allows you do work more directly on the books, e.g.
 * Use `parameters.yml` to set `publisher_repos_dir`. This way your books don't live inside the `var/cache/` directory (which gets deleted every now and then... which is a bit annoying...).
 * Use `bin/console docs:serve` to setup a temp HTTP server with live-reload support.
