### PR TITLE
Mark master branch as stable for Dev Guide

### DIFF
--- a/app/config/books/dev.yml
+++ b/app/config/books/dev.yml
@@ -4,4 +4,4 @@ langs:
     en:
         repo: 'https://github.com/civicrm/civicrm-dev-docs'
         latest: master
-        #stable: master
+        stable: master


### PR DESCRIPTION
specifying that the Dev Guide can use the master branch as a stable version so that it will show up on the docs home page

Fixes #28 