### PR TITLE
Handle Concurrent Publish Requests

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -42,3 +42,9 @@ services:
     class: Monolog\Handler\StreamHandler
     arguments:
       - %kernel.logs_dir%/publish.log
+
+  lockfile_handler:
+    class: AppBundle\Utils\LockFileHandler
+    arguments:
+     - '%kernel.cache_dir%'
+     - 1800

--- a/src/AppBundle/Utils/LockFileHandler.php
+++ b/src/AppBundle/Utils/LockFileHandler.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace AppBundle\Utils;
+
+class LockFileHandler {
+
+  /**
+   * @var string
+   *   Where the lock files will be stored.
+   */
+  protected $lockDirectory;
+
+  /**
+   * @var int
+   *   How many seconds a lock remains active
+   */
+  protected $lockLifetimeInSeconds;
+
+  /**
+   * @param $cacheDir
+   *  The cache directory for the current environment
+   * @param $lockLifetimeInSeconds
+   *  How many seconds a lock remains active
+   */
+  public function __construct($cacheDir, $lockLifetimeInSeconds)
+  {
+    $lockDirectory = $cacheDir . '/locks';
+
+    if (!is_dir($lockDirectory)) {
+      mkdir($lockDirectory, 0777, true);
+    }
+
+    $this->lockDirectory = $lockDirectory;
+    $this->lockLifetimeInSeconds = (int) $lockLifetimeInSeconds;
+  }
+
+  /**
+   * Creates a lock file or updates an existing one
+   *
+   * @param string $name
+   */
+  public function create($name) {
+    $name = trim($name);
+
+    if (!$name) {
+      throw new \Exception('Lock file name cannot be empty');
+    }
+
+    $lockFilename = $this->getFullFilename($name);
+    touch($lockFilename);
+  }
+
+  /**
+   * Check if a lock file exists. Removes it if it is expired.
+   *
+   * @param string $name
+   * @return bool
+   */
+  public function exists($name) {
+    $lockFilename = $this->getFullFilename($name);
+    $exists = file_exists($lockFilename);
+
+    if ($exists && $this->isExpired($lockFilename)) {
+      $this->release($name);
+      $exists = FALSE;
+    }
+
+    return $exists;
+  }
+
+  /**
+   * Removes a lock file. Non-existing locks are ignored
+   *
+   * @param $name
+   */
+  public function release($name) {
+    $lockFilename = $this->getFullFilename($name);
+
+    if (!file_exists($lockFilename)) {
+      return;
+    }
+
+    unlink($lockFilename);
+  }
+
+  /**
+   * @param $name
+   *
+   * @return string
+   */
+  protected function getFullFilename($name)
+  {
+    $lockFilename = sprintf('%s/%s', $this->lockDirectory, $name);
+
+    return $lockFilename;
+  }
+
+  /**
+   * Checks if a lock file was last modified in the last LOCK_EXPIRY seconds
+   *
+   * @param $lockFilename
+   *  The full filename
+   *
+   * @return bool
+   */
+  protected function isExpired($lockFilename)
+  {
+    $lastModified = filemtime($lockFilename);
+    $expiresAt = $lastModified + $this->lockLifetimeInSeconds;
+    $now = time();
+
+    return $now > $expiresAt;
+  }
+
+}

--- a/tests/AppBundle/Utils/LockFileHandlerTest.php
+++ b/tests/AppBundle/Utils/LockFileHandlerTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace AppBundle\Tests\Utils;
+
+use AppBundle\Utils\LockFileHandler;
+
+class LockFileHandlerTest extends \PHPUnit_Framework_TestCase
+{
+  /**
+   * @var string
+   */
+  protected $lockDir;
+
+  /**
+   * @test
+   */
+  public function canCreateLockFile() {
+    $handler = $this->getHandler();
+    $handler->create('foo');
+
+    $this->assertTrue($handler->exists('foo'));
+  }
+
+  /**
+   * @test
+   */
+  public function creationAndDeletionWillWork() {
+    $handler = $this->getHandler();
+    $handler->create('foo');
+    $handler->release('foo');
+
+    $this->assertFalse($handler->exists('foo'));
+  }
+
+  /**
+   * @test
+   */
+  public function nonExistingLockWillReturnFalse() {
+    $handler = $this->getHandler();
+
+    $this->assertFalse($handler->exists('foo'));
+  }
+
+  /**
+   * @test
+   */
+  public function releaseWithNonExistingLockWillDoNothing() {
+    $this->getHandler()->release('foo');
+  }
+
+  /**
+   * @test
+   */
+  public function createWithExistingLockWillDoNothing() {
+    $handler = $this->getHandler();
+    $handler->create('foo');
+    $handler->create('foo');
+
+    $this->assertTrue($handler->exists('foo'));
+  }
+
+  /**
+   * @test
+   */
+  public function expiryWillWork() {
+    $handler = $this->getHandler(0);
+    $handler->create('foo');
+    sleep(1);
+
+    $this->assertFalse($handler->exists('foo'));
+  }
+
+  /**
+   * @test
+   */
+  public function recreatingALockWillResetExpiry() {
+    $handler = $this->getHandler(1);
+    $handler->create('foo');
+    sleep(2);
+    $handler->create('foo'); // first lock would have expired
+
+    $this->assertTrue($handler->exists('foo'));
+  }
+
+  /**
+   * @param int $lockTTL
+   *   How long the lock will remain active
+   *
+   * @return LockFileHandler
+   */
+  private function getHandler($lockTTL = 5) {
+    return new LockFileHandler($this->lockDir, $lockTTL);
+  }
+
+  /**
+   * Create the lock directory in temp directory
+   */
+  protected function setUp() {
+    $this->lockDir = sys_get_temp_dir() . '/civicrm-docs-test-locks';
+  }
+
+  /**
+   * Removes all locks in the temp lock directory
+   */
+  protected function tearDown() {
+    array_map('unlink', glob($this->lockDir . '/locks/*'));
+  }
+
+}


### PR DESCRIPTION
## Description
As mentioned in #52  if we have concurrent requests to publish books then it doesn't make sense to process both of them.

## Before
Concurrent requests to publish would publish the same guides twice.

## After
While a publishing request is in process any other publishing requests will fail with status 409 and an error message.

- [ ] Tests pass
I've created tests for the new code, but existing tests are still broken. All tests are fixed in #64 so I won't duplicate that here.