### PR TITLE
Create civiproxy.yml

### DIFF
--- a/books/civiproxy.yml
+++ b/books/civiproxy.yml
@@ -2,4 +2,4 @@ name: CiviProxy
 description: Scripts to install on separate server to police data traffic between CiviCRM on a secure server and the outside world
 langs:
   en:
-repo: 'https://github.com/systopia/CiviProxy' 
+    repo: 'https://github.com/systopia/CiviProxy'

--- a/books/civiproxy.yml
+++ b/books/civiproxy.yml
@@ -1,0 +1,5 @@
+name: CiviProxy
+description: Scripts to install on separate server to police data traffic between CiviCRM on a secure server and the outside world
+langs:
+  en:
+repo: 'https://github.com/systopia/CiviProxy' 


### PR DESCRIPTION
Would like to add the CiviProxy Guide to civicrm-docs as a separate book.

Remark: I had some trouble understanding this part of the documentation guide:

> When you're ready, you make a pull request on our publishing system to add the necessary configuration for your guide, so that it gets published to docs.civicrm.org.

It was not immediately clear to me that I had to fork the repo and add my own yml file. Would probably be nice to include that part in the documentation guide to?