### PR TITLE
Improve schema of user book yaml file for catalan

### DIFF
--- a/books/user.yml
+++ b/books/user.yml
@@ -20,6 +20,14 @@ langs:
           - lts
   ca:
     repo: 'https://github.com/babu-cat/civicrm-user-guide-ca'
+    versions:
+      4.7:                    # This is stored as $slug
+        name: 4.7 / Latest    # If omitted, use $slug
+        path: latest          # If omitted, use a URL-safe version of $slug
+        branch: master        # If omitted, use $slug
+        redirects:            # These are not displayed anywhere
+          - current
+          - stable
   fr:
     repo: 'https://github.com/civicrm-french/civicrm-user-guide'
   es:


### PR DESCRIPTION
I can't publish catalan book with manual method calling https://docs.civicrm.org/admin/publish/user/ca/master. I suspect is due to this missing configuration due to this commit https://github.com/civicrm/civicrm-docs/commit/09a0092f2bd0238b1041c5f1f502c87c777d3f34#diff-a54cf6d3112bfba008bfa523c3b75a55